### PR TITLE
add dynamic slspath instead of harcode

### DIFF
--- a/automation_modules/salt/pica8_config/init.sls
+++ b/automation_modules/salt/pica8_config/init.sls
@@ -9,4 +9,4 @@ override_config:
 config:
   file.managed:
     - name: /pica/config/salt_pica.conf
-    - source: salt://pica8_config/files/{{ grains['localhost'] }}_pica.conf
+    - source: salt://{{slspath}}/files/{{ opts.id }}_pica.conf


### PR DESCRIPTION
use opts.id as minio_id to make sure config file is deployed to right minio
add dynamic slspath instead of harcode to help someone didn't want use default folder name `pica8_config` without change init.sls files